### PR TITLE
getLastEndpoint() for unbinding and disconnecting sockets

### DIFF
--- a/src/ofxZmqSocket.cpp
+++ b/src/ofxZmqSocket.cpp
@@ -47,6 +47,12 @@ void ofxZmqSocket::unbind(string addr)
 	socket.unbind(addr.c_str());
 }
 
+string ofxZmqSocket::getLastEndpoint() {
+    char port[1024];
+    size_t size = sizeof(port);
+    socket.getsockopt(ZMQ_LAST_ENDPOINT, &port, &size);
+    return std::string( port );
+}
 
 bool ofxZmqSocket::send(const void *data, size_t len, bool nonblocking, bool more)
 {

--- a/src/ofxZmqSocket.h
+++ b/src/ofxZmqSocket.h
@@ -24,6 +24,8 @@ public:
 	long getSendHighWaterMark();
 	long getReceiveHighWaterMark();
 
+    string getLastEndpoint();
+
 protected:
 
 	zmq::socket_t socket;


### PR DESCRIPTION
A method that can be used to unbind / disconnect a socket when it has been created with a wildcard: https://github.com/zeromq/pyzmq/issues/1025

ie.

```
    publisher->unbind( publisher->getLastEndpoint() ) ;
    subscriber->disconnect( subscriber->getLastEndpoint() ) ;
```